### PR TITLE
63 uiux improvements in the integration section

### DIFF
--- a/src/components/Integrations/NoIntegrationsAction.vue
+++ b/src/components/Integrations/NoIntegrationsAction.vue
@@ -1,0 +1,23 @@
+<template>
+  <div>
+    {{ $t("messages.information.noIntegration1") }}
+    <router-link to="/integrations" target="_blank" class="text-primary">
+      {{ $t("action.clickHere") }}
+      <q-icon
+        name="eva-external-link-outline"
+        size="14px"
+        style="margin-bottom: 6px"
+      />
+    </router-link>
+    {{ $t("messages.information.noIntegration2") }}
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'ComponentNoIntegrationsAction',
+  setup() {
+    return {};
+  },
+};
+</script>

--- a/src/i18n/en-US/index.js
+++ b/src/i18n/en-US/index.js
@@ -114,6 +114,7 @@ export default {
     timezoneSaved: 'Timezone saved',
     checkDisabled: 'Check disabled',
     checkEnabled: 'Check enabled',
+    clickHere: 'Click here',
   },
   messages: {
     information: {
@@ -157,6 +158,8 @@ export default {
       authenticationDescription: 'Use a authentication header to authenticate your requests to your service.',
       writeACustomValueAndPressEnter: 'Write a custom value and press enter',
       authorizationHeaderConfigured: 'Authorization header configured',
+      noIntegration1: 'You haven`t added any integration yet,',
+      noIntegration2: 'to open a new tab and create your first integration to receive notifications.'
     },
     errors: {
       requireField: 'This field is required',

--- a/src/pages/Checks/Add.vue
+++ b/src/pages/Checks/Add.vue
@@ -141,6 +141,9 @@
                 <q-separator />
               </div>
             </template>
+            <template v-if="integrations.length === 0">
+              <NoIntegrationsAction />
+            </template>
           </div>
           <div class="text-center">
             <q-btn
@@ -168,10 +171,11 @@ import SmallIntegrationIcon from "components/Integrations/Icons/Small";
 import jwtDecode from "jwt-decode";
 import RoleBadge from "components/User/RoleBadge.vue";
 import timezonesJson from "assets/timezones.json";
+import NoIntegrationsAction from "components/Integrations/NoIntegrationsAction.vue";
 
 export default {
   name: "PageCheckForm",
-  components: { SmallIntegrationIcon, RoleBadge },
+  components: { SmallIntegrationIcon, RoleBadge, NoIntegrationsAction },
   setup() {
     const $q = useQuasar();
     const $store = useStore();

--- a/src/pages/Checks/Add.vue
+++ b/src/pages/Checks/Add.vue
@@ -129,7 +129,14 @@
             </div>
           </div>
           <div>
-            <p class="text-bold">{{ $t("common.integrations") }}</p>
+            <p class="text-bold">
+              {{ $t("common.integrations") }}
+              <q-spinner
+                v-show="loadingIntegrations"
+                color="primary"
+                size="1em"
+              />
+            </p>
             <template v-for="integration in integrations" :key="integration.id">
               <div>
                 <q-toggle
@@ -163,7 +170,7 @@
 
 <script>
 import { useQuasar } from "quasar";
-import { ref } from "vue";
+import { ref, onMounted, onUnmounted } from "vue";
 import { useStore } from "vuex";
 import { useRouter } from "vue-router";
 import { useI18n } from "vue-i18n";
@@ -181,6 +188,7 @@ export default {
     const $store = useStore();
     const $router = useRouter();
     const $t = useI18n().t;
+    const loadingIntegrations = ref(false);
     const timezones = ref([]);
     const useAuthorizationHeader = ref(false);
     const commonAuthorizationHeader = ref([
@@ -189,6 +197,33 @@ export default {
       "X-Auth-Key",
     ]);
     const refAuthorizationHeaderDropdown = ref(null);
+
+    const fetchIntegrations = () => {
+      loadingIntegrations.value = true;
+
+      $store
+        .dispatch("integrations/fetchAll")
+        .then((response) => {
+          integrations.value = response.data.data;
+        })
+        .finally(() => {
+          loadingIntegrations.value = false;
+        });
+    };
+
+    const checkTabFocused = () => {
+      if (document.visibilityState === "visible") {
+        fetchIntegrations();
+      }
+    };
+
+    onMounted(() => {
+      document.addEventListener("visibilitychange", checkTabFocused);
+    });
+
+    onUnmounted(() => {
+      document.removeEventListener("visibilitychange", checkTabFocused);
+    });
 
     const check = ref({
       name: "",
@@ -212,13 +247,12 @@ export default {
       )
     );
 
-    $store.dispatch("integrations/fetchAll").then((response) => {
-      integrations.value = response.data.data;
-    });
+    fetchIntegrations();
 
     return {
       check,
       loading,
+      loadingIntegrations,
       periods,
       integrations,
       timezones,

--- a/src/pages/Checks/Edit.vue
+++ b/src/pages/Checks/Edit.vue
@@ -157,6 +157,9 @@
                 <q-separator />
               </div>
             </template>
+            <template v-if="integrations.length === 0">
+              <NoIntegrationsAction />
+            </template>
           </div>
           <div class="text-center">
             <q-btn
@@ -177,10 +180,11 @@
 import SmallIntegrationIcon from "components/Integrations/Icons/Small";
 import RoleBadge from "components/User/RoleBadge.vue";
 import timezonesJson from "assets/timezones.json";
+import NoIntegrationsAction from "components/Integrations/NoIntegrationsAction.vue";
 
 export default {
   name: "PageCheckEdit",
-  components: { SmallIntegrationIcon, RoleBadge },
+  components: { SmallIntegrationIcon, RoleBadge, NoIntegrationsAction },
   created() {
     this.$q.loading.show();
 

--- a/src/pages/Checks/Edit.vue
+++ b/src/pages/Checks/Edit.vue
@@ -144,7 +144,14 @@
             </div>
           </div>
           <div>
-            <p class="text-bold">{{ $t("common.integrations") }}</p>
+            <p class="text-bold">
+              {{ $t("common.integrations") }}
+              <q-spinner
+                v-show="loadingIntegrations"
+                color="primary"
+                size="1em"
+              />
+            </p>
             <template v-for="integration in integrations" :key="integration.id">
               <div>
                 <q-toggle
@@ -228,6 +235,12 @@ export default {
         this.$q.loading.hide();
       });
   },
+  mounted() {
+    document.addEventListener("visibilitychange", this.fetchIntegrationsOnFocusWindow);
+  },
+  unmounted() {
+    document.removeEventListener("visibilitychange", this.fetchIntegrationsOnFocusWindow);
+  },
   data() {
     return {
       check: {
@@ -253,6 +266,7 @@ export default {
       ],
       refAuthorizationHeaderDropdown: null,
       loading: false,
+      loadingIntegrations: false,
       timezones: [],
       periods: this.$store.getters["checks/getPeriods"].filter((period) =>
         period.roles.includes(
@@ -263,6 +277,18 @@ export default {
     };
   },
   methods: {
+    fetchIntegrationsOnFocusWindow() {
+      if (document.visibilityState === "visible") {
+        this.$store
+          .dispatch("integrations/fetchAll")
+          .then((response) => {
+            this.integrations = response.data.data;
+          })
+          .finally(() => {
+            this.loadingIntegrations = false;
+          });
+      }
+    },
     onToggleIntegration(integrationId) {
       const isChecked = this.check.currentIntegrations.includes(integrationId);
       const isOnCurrent = this.check.check_integrations.find(

--- a/tests/integrations/NoIntegrationsAction.test.js
+++ b/tests/integrations/NoIntegrationsAction.test.js
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { Quasar } from 'quasar'
+
+import NoIntegrationsAction from "../../src/components/Integrations/NoIntegrationsAction.vue";
+
+const wrapperFactory = () => mount(NoIntegrationsAction, {
+  global: {
+    plugins: [Quasar],
+    mocks: {
+      $t: (msg) => msg
+    }
+  }
+})
+
+const wrapper = wrapperFactory();
+
+describe('No integrations action component', () => {
+  it('mount component', () => {
+    expect(NoIntegrationsAction).toBeTruthy();
+  })
+
+  it('should be have a text', () => {
+    expect(wrapper.text()).toContain('messages.information.noIntegration1');
+    expect(wrapper.text()).toContain('messages.information.noIntegration2');
+    expect(wrapper.text()).toContain('action.clickHere');
+  })
+
+  it('should be have a link', () => {
+    const link = wrapper.find('router-link');
+    expect(link.exists()).toBe(true);
+  })
+
+})


### PR DESCRIPTION
### General
#63 I Added a message for the first time users or when the user not have any integration created;

![image](https://user-images.githubusercontent.com/35310226/197913983-b01a145f-42a9-4f40-9604-98e24f507a83.png)

Additional to this, when the user clicked the link and create an integration and go back to the check page, the app fetch for integrations only when the user focuses the window.

- [x] Loading state added
- [x] More interactive section
- [x] Unit tests

### Type

> ℹ️  What types of changes does your code introduce?

> 👉 _Put an `x` in the boxes that apply_

- [x] Feature
