### PR TITLE
added word-wrap in target on responsive mode

### DIFF
--- a/src/pages/Checks/Index.vue
+++ b/src/pages/Checks/Index.vue
@@ -78,7 +78,7 @@
               <div class="text-grey-8">{{ $t("common.name") }}</div>
               <div class="q-mb-sm">{{ props.row.name }}</div>
               <div class="text-grey-8">{{ $t("common.target") }}</div>
-              <div class="q-mb-sm">{{ props.row.target }}</div>
+              <div class="q-mb-sm text-wrap">{{ props.row.target }}</div>
               <div class="text-grey-8">{{ $t("common.integrations") }}</div>
               <div class="q-mb-sm">
                 <template
@@ -709,3 +709,9 @@ export default {
   },
 };
 </script>
+
+<style>
+.text-wrap {
+  word-wrap: break-word;
+}
+</style>


### PR DESCRIPTION
### General
Added a simple but strong word-wrap in target #118 

### Type
CSS

- [x] Fix
- [ ] Feature

### Describe the changes here (summarized)

<table>
   <th><tr><td>BEFORE</td><td>AFTER</td></tr></th>
    <tr>
        <td><image src="https://github.com/ta-vivo/ta-vivo/assets/44907530/2ae8847f-5480-4cbf-8019-d49c90c5ca0e" /></td>
       <td><image src="https://github.com/ta-vivo/ta-vivo/assets/44907530/91641246-39f7-45f2-b8f3-1d6606d55cb3"></td>
    </tr>
</table>
