### PR TITLE
UI/fix telegram image

### DIFF
--- a/src/components/Integrations/Form/Telegram.vue
+++ b/src/components/Integrations/Form/Telegram.vue
@@ -57,13 +57,13 @@
           >@ta-vivo-bot</a
         >
       </p>
-      <p>
-        <span class="text-bold">2-</span> {{ $t("messages.information.telegramSetupBotCommand") }}
+      <span class="text-bold">2-</span> {{ $t("messages.information.telegramSetupBotCommand") }}
+      <p class="text-center">
         <q-img
           class="q-mt-md telegram-demo"
           src="~assets/telegram/telegram-bot-command.jpeg"
           spinner-color="white"
-          style="max-width: 80%"
+          :style="$q.screen.xs ? 'max-width: 100%' : 'max-width: 60%'"
         />
       </p>
     </div>

--- a/src/pages/Checks/Index.vue
+++ b/src/pages/Checks/Index.vue
@@ -78,7 +78,7 @@
               <div class="text-grey-8">{{ $t("common.name") }}</div>
               <div class="q-mb-sm">{{ props.row.name }}</div>
               <div class="text-grey-8">{{ $t("common.target") }}</div>
-              <div class="q-mb-sm">{{ props.row.target }}</div>
+              <div class="q-mb-sm text-wrap">{{ props.row.target }}</div>
               <div class="text-grey-8">{{ $t("common.integrations") }}</div>
               <div class="q-mb-sm">
                 <template
@@ -709,3 +709,9 @@ export default {
   },
 };
 </script>
+
+<style>
+.text-wrap {
+  word-wrap: break-word;
+}
+</style>


### PR DESCRIPTION
### General
Changed the size of the image and reposition it to center of the container. #120 

### Type
CSS

- [x] Fix
- [ ] Feature

### Describe the changes here (summarized)

In larger screens the width  was changed from 80% to 60%, it maintains clarity of the image and make it more visible without scrolling. On the other hand, in smaller screens width changed to 100% for more balanced view of items on the screen.

<table>
    <th><tr><td>PC (Now occupates 60% of the space)</td><td>Mobile (100% of the space taken)</td></tr></th>
    <tr>
        <td><image src="https://github.com/ta-vivo/ta-vivo/assets/44907530/6438bcb2-e738-4500-8fdd-952fb6421028"></td>
         <td><image src="https://github.com/ta-vivo/ta-vivo/assets/44907530/cc1cfb59-fbbc-43d5-802c-f7ad148c78c7"></td>
    </tr>
</table
